### PR TITLE
Bugfix cmfkit cmakedefs

### DIFF
--- a/.cmfkit/scenario/egyro
+++ b/.cmfkit/scenario/egyro
@@ -14,11 +14,11 @@ __import() {
 __build() {
 
   # set default cmake build type: 'Release'
-  CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"
+  CMAKE_BUILD_TYPE="\"${CMAKE_BUILD_TYPE:-Release}\""
 
   # set compiler flag hdf5 double precision
-  CMAKE_Fortran_FLAGS="-DHDF5_DOUBLE_PRESICION"
-  CMAKE_Fortran_FLAGS_DEBUG=-g;-ffpe-trap=invalid,zero,overflow
+  CMAKE_Fortran_FLAGS="\"-DHDF5_DOUBLE_PRESICION\""
+  CMAKE_Fortran_FLAGS_DEBUG="\"-g -ffpe-trap=invalid,zero,overflow\""
 
   # commit outstanding CMake def variables to the final roster
   _deflist_accrue_vars
@@ -30,7 +30,8 @@ __build() {
   _deflist_report_cmdline
 
   mkdir -p ./build && cd $_
-  cmake $CMFKIT_CMDLINE_CMAKE_DEFINITIONS .. && make VERBOSE=1\
+
+  cmake "$CMFKIT_CMDLINE_CMAKE_DEFINITIONS" .. && make VERBOSE=1 \
     || return 1
 }
 

--- a/.cmfkit_base/mod_deflist
+++ b/.cmfkit_base/mod_deflist
@@ -96,20 +96,10 @@ _deflist_render_cmdline() {
 
 _deflist_report_cmdline() {
 
-  read -r cmake_defs <<< $(
-  echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
-    do [[ -n $a ]] || break
-      echo "${a:+ }-D${a}=${!a}"
-    done
-    echo
-  )
-
   echo "."
   echo "."
   echo "cmfkit >> [Info] << cmdline CMake definitions"
   echo "."
-  #echo " ${cmake_defs[@]}" | sed 's/\n/\n  /g'
-
   echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
     do [[ -n $a ]] || break
       echo "${a:+ }-D${a}=${!a}"

--- a/.cmfkit_base/mod_deflist
+++ b/.cmfkit_base/mod_deflist
@@ -82,7 +82,7 @@ _deflist_export_vars() {
 
 _deflist_render_cmdline() {
 
-  readarray cmake_defs <<< $(
+  read -r cmake_defs <<< $(
   echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
     do [[ -n $a ]] || break
       echo -n "${a:+ }-D${a}=${!a}"
@@ -96,7 +96,7 @@ _deflist_render_cmdline() {
 
 _deflist_report_cmdline() {
 
-  readarray cmake_defs <<< $(
+  read -r cmake_defs <<< $(
   echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
     do [[ -n $a ]] || break
       echo "${a:+ }-D${a}=${!a}"
@@ -108,7 +108,12 @@ _deflist_report_cmdline() {
   echo "."
   echo "cmfkit >> [Info] << cmdline CMake definitions"
   echo "."
-  echo " ${cmake_defs[@]}" | sed 's/\n/\n  /g'
+  #echo " ${cmake_defs[@]}" | sed 's/\n/\n  /g'
+
+  echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
+    do [[ -n $a ]] || break
+      echo "${a:+ }-D${a}=${!a}"
+    done
   echo "."
   echo "."
   echo; echo

--- a/.cmfkit_base/mod_deflist
+++ b/.cmfkit_base/mod_deflist
@@ -85,12 +85,12 @@ _deflist_render_cmdline() {
   readarray cmake_defs <<< $(
   echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
     do [[ -n $a ]] || break
-      echo -n "${a:+ }-D${a}=\"${!a}\""
+      echo -n "${a:+ }-D${a}=${!a}"
     done
     echo
   )
-
-  read CMFKIT_CMDLINE_CMAKE_DEFINITIONS <<< $( echo ${cmake_defs[@]} | tr '\n' ' ')
+  
+  read CMFKIT_CMDLINE_CMAKE_DEFINITIONS <<< $( echo -n "${cmake_defs[@]}" )
 }
 
 

--- a/.cmfkit_base/mod_deflist
+++ b/.cmfkit_base/mod_deflist
@@ -99,7 +99,7 @@ _deflist_report_cmdline() {
   readarray cmake_defs <<< $(
   echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
     do [[ -n $a ]] || break
-      echo "${a:+ }-D${a}=\"${!a}\""
+      echo "${a:+ }-D${a}=${!a}"
     done
     echo
   )

--- a/.cmfkit_base/mod_deflist
+++ b/.cmfkit_base/mod_deflist
@@ -82,25 +82,33 @@ _deflist_export_vars() {
 
 _deflist_render_cmdline() {
 
-  read cmake_defs <<< $(
+  readarray cmake_defs <<< $(
   echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
     do [[ -n $a ]] || break
-      echo -n "${a:+ }-D${a}=${!a}"
+      echo -n "${a:+ }-D${a}=\"${!a}\""
     done
     echo
   )
 
-  CMFKIT_CMDLINE_CMAKE_DEFINITIONS="${cmake_defs}"
+  read CMFKIT_CMDLINE_CMAKE_DEFINITIONS <<< $( echo ${cmake_defs[@]} | tr '\n' ' ')
 }
 
 
 _deflist_report_cmdline() {
 
+  readarray cmake_defs <<< $(
+  echo $CMFKIT_VARLIST_CMAKE_DEFINITIONS | tr ' ' '\n' | while read a
+    do [[ -n $a ]] || break
+      echo "${a:+ }-D${a}=\"${!a}\""
+    done
+    echo
+  )
+
   echo "."
   echo "."
   echo "cmfkit >> [Info] << cmdline CMake definitions"
-  echo -n "."
-  echo " $CMFKIT_CMDLINE_CMAKE_DEFINITIONS" | sed 's/ /\n  /g'
+  echo "."
+  echo " ${cmake_defs[@]}" | sed 's/\n/\n  /g'
   echo "."
   echo "."
   echo; echo

--- a/.cmfkit_base/platform/github-vm-macos-latest/setup
+++ b/.cmfkit_base/platform/github-vm-macos-latest/setup
@@ -2,5 +2,5 @@
 
 brew install hdf5 open-mpi
 
-#CMAKE_Fortran_COMPILER=/usr/local/opt/gfortran/bin/gfortran
+CMAKE_Fortran_COMPILER=/usr/local/opt/gfortran/bin/gfortran
 

--- a/.cmfkit_base/platform/github-vm-macos-latest/setup
+++ b/.cmfkit_base/platform/github-vm-macos-latest/setup
@@ -2,5 +2,5 @@
 
 brew install hdf5 open-mpi
 
-CMAKE_Fortran_COMPILER=/usr/local/opt/gfortran/bin/gfortran
+#CMAKE_Fortran_COMPILER=/usr/local/opt/gfortran/bin/gfortran
 


### PR DESCRIPTION
A bug was identified that prevented spaces from being used for custom defined cmake definitions in cmfkit.  Double quotes are now preserved such that the cmake definition values can contain spaces.