### PR TITLE
Call destruction destructors after constructing random state objects.

### DIFF
--- a/src/korc_c_random.cpp
+++ b/src/korc_c_random.cpp
@@ -58,11 +58,11 @@ extern "C" {
         return static_cast<class random_N *> (r)->get_number_N();
     }
   
-    void random_N_destroy(void *r) {
+    void random_destroy_N(void *r) {
         delete  static_cast<class random_N *> (r);
     }
   
-    void random_U_destroy(void *r) {
+    void random_destroy_U(void *r) {
         delete  static_cast<class random_U *> (r);
     }
 

--- a/src/korc_experimental_pdf.f90
+++ b/src/korc_experimental_pdf.f90
@@ -939,6 +939,9 @@ CONTAINS
 
  !   write(output_unit_write,'("sampled eta: ",E17.10)') eta
     
+     if (.not.params%SameRandSeed) then
+        call finalize_random_seed
+     end if
   END SUBROUTINE sample_Hollmann_distribution
 
 FUNCTION PSI_ROT_exp(R,R0,sigR,Z,Z0,sigZ,theta)
@@ -1383,7 +1386,10 @@ subroutine sample_Hollmann_distribution_3D(params,spp,F)
 !     write(output_unit_write,*) 'Z_samples',Z_samples
 !     write(output_unit_write,*) 'G_samples',G_samples
 !     write(output_unit_write,*) 'eta_samples',eta_samples
-     
+  
+     if (.not.params%SameRandSeed) then
+        call finalize_random_seed
+     end if
   end if
 
 
@@ -1971,7 +1977,10 @@ subroutine sample_Hollmann_distribution_3D_psi(params,spp,F)
      if (TRIM(h_params%current_direction) .EQ. 'PARALLEL') then
         eta_samples = 180.0_rp - eta_samples
      end if
-     
+  
+     if (.not.params%SameRandSeed) then
+        call finalize_random_seed
+     end if
   end if
 
   params%GC_coords=.FALSE.
@@ -2506,7 +2515,10 @@ subroutine sample_Hollmann_distribution_1Dtransport(params,spp,F)
      if (TRIM(h_params%current_direction) .EQ. 'PARALLEL') then
         eta_samples = 180.0_rp - eta_samples
      end if
-     
+  
+     if (.not.params%SameRandSeed) then
+        call finalize_random_seed
+     end if
   end if
 
   params%GC_coords=.FALSE.

--- a/src/korc_fields.f90
+++ b/src/korc_fields.f90
@@ -1161,6 +1161,8 @@ subroutine unitVectors(params,Xo,F,b1,b2,b3,flag,cart,hint,Bo)
 
    !write(output_unit_write,*) 'out unitVectors'
 
+   call finalize_random_seed
+
 end subroutine unitVectors
 
 

--- a/src/korc_initialize.f90
+++ b/src/korc_initialize.f90
@@ -738,4 +738,14 @@ CONTAINS
 
   end subroutine set_up_particles_ic
 
+  subroutine take_down_particles_ic(params)
+    implicit none
+
+    TYPE(KORC_PARAMS), INTENT(INOUT)                 :: params
+    !! Core KORC simulation parameters.
+
+    if (params%restart.OR.params%proceed.or.params%reinit) then
+       call finalize_random_seed
+    end if
+  end subroutine
 end module korc_initialize

--- a/src/korc_random.f90
+++ b/src/korc_random.f90
@@ -104,6 +104,7 @@ MODULE korc_random
   END INTERFACE
   
   PUBLIC :: initialize_random
+  PUBLIC :: finalize_random
 
 CONTAINS
 
@@ -125,6 +126,16 @@ CONTAINS
     !$OMP END PARALLEL
   END SUBROUTINE initialize_random
 
+  SUBROUTINE finalize_random
+    IMPLICIT NONE
+
+    INTEGER             :: thread_num
+    !$OMP PARALLEL
+    thread_num = get_thread_number()
+    CALL random_destroy_U(states(thread_num))
+    !$OMP END PARALLEL
+  END SUBROUTINE
+
   SUBROUTINE initialize_random_U(seed)
     IMPLICIT NONE
 
@@ -134,6 +145,12 @@ CONTAINS
 
   END SUBROUTINE initialize_random_U
 
+  SUBROUTINE finalize_random_U
+    IMPLICIT NONE
+
+    CALL random_destroy_U(state)
+  END SUBROUTINE
+
   SUBROUTINE initialize_random_N(seed)
     IMPLICIT NONE
 
@@ -142,7 +159,13 @@ CONTAINS
     state = random_construct_N(seed)
 
   END SUBROUTINE initialize_random_N
-  
+
+  SUBROUTINE finalize_random_N
+    IMPLICIT NONE
+
+    CALL random_destroy_N(state)
+  END SUBROUTINE
+
   FUNCTION get_random()
     IMPLICIT NONE
 

--- a/src/korc_random.f90
+++ b/src/korc_random.f90
@@ -11,7 +11,8 @@ MODULE korc_random
   IMPLICIT NONE
 
   TYPE(C_PTR), DIMENSION(:), ALLOCATABLE , PRIVATE :: states
-  TYPE(C_PTR),  PRIVATE :: state
+  TYPE(C_PTR),  PRIVATE :: state_u
+  TYPE(C_PTR),  PRIVATE :: state_n
   !    TYPE(VSL_STREAM_STATE), PRIVATE :: stream
 
   INTERFACE
@@ -130,10 +131,13 @@ CONTAINS
     IMPLICIT NONE
 
     INTEGER             :: thread_num
-    !$OMP PARALLEL
+
+    !$OMP PARALLEL PRIVATE(thread_num)
     thread_num = get_thread_number()
     CALL random_destroy_U(states(thread_num))
     !$OMP END PARALLEL
+
+    DEALLOCATE (states)
   END SUBROUTINE
 
   SUBROUTINE initialize_random_U(seed)
@@ -141,14 +145,14 @@ CONTAINS
 
     INTEGER, INTENT(IN) :: seed
 
-    state = random_construct_U(seed)
+    state_u = random_construct_U(seed)
 
   END SUBROUTINE initialize_random_U
 
   SUBROUTINE finalize_random_U
     IMPLICIT NONE
 
-    CALL random_destroy_U(state)
+    CALL random_destroy_U(state_u)
   END SUBROUTINE
 
   SUBROUTINE initialize_random_N(seed)
@@ -156,14 +160,14 @@ CONTAINS
 
     INTEGER, INTENT(IN) :: seed
 
-    state = random_construct_N(seed)
+    state_n = random_construct_N(seed)
 
   END SUBROUTINE initialize_random_N
 
   SUBROUTINE finalize_random_N
     IMPLICIT NONE
 
-    CALL random_destroy_N(state)
+    CALL random_destroy_N(state_n)
   END SUBROUTINE
 
   FUNCTION get_random()
@@ -179,7 +183,7 @@ CONTAINS
 
     REAL(rp)            :: get_random_U
 
-    get_random_U = random_get_number_U(state)
+    get_random_U = random_get_number_U(state_u)
   END FUNCTION get_random_U
 
   FUNCTION get_random_N()
@@ -187,7 +191,7 @@ CONTAINS
 
     REAL(rp)            :: get_random_N
 
-    get_random_N = random_get_number_N(state)
+    get_random_N = random_get_number_N(state_n)
   END FUNCTION get_random_N
 
   SUBROUTINE get_randoms(nums)

--- a/src/korc_rnd_numbers.f90
+++ b/src/korc_rnd_numbers.f90
@@ -183,4 +183,19 @@ contains
   end function lcg
 end subroutine init_random_seed
 
+subroutine finalize_random_seed
+#ifdef PARALLEL_RANDOM
+  use korc_random
+#endif
+
+implicit none
+
+#ifdef PARALLEL_RANDOM
+call finalize_random
+call finalize_random_U
+call finalize_random_N
+#endif
+
+end subroutine
+
 end module korc_rnd_numbers

--- a/src/korc_spatial_distribution.f90
+++ b/src/korc_spatial_distribution.f90
@@ -100,12 +100,15 @@ subroutine disk(params,spp)
 
   call init_random_seed(params)
   call RANDOM_NUMBER(theta)
+  call finalize_random_seed
 
   theta = 2.0_rp*C_PI*theta
 
   ! Uniform distribution on a disk at a fixed azimuthal theta
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(r)
+  call finalize_random_seed
 
   r = SQRT((spp%r_outter**2 - spp%r_inner**2)*r + spp%r_inner**2)
   spp%vars%X(:,1) = ( spp%Ro + r*COS(theta) )*COS(spp%PHIo)
@@ -162,6 +165,8 @@ subroutine torus(params,spp)
     DEALLOCATE(theta)
     DEALLOCATE(zeta)
     DEALLOCATE(r)
+
+    call finalize_random_seed
 end subroutine torus
 
 !subroutine torus(params,spp)
@@ -312,14 +317,19 @@ subroutine elliptic_torus(params,spp)
   call init_random_seed(params)
   call RANDOM_NUMBER(theta)
   theta = 2.0_rp*C_PI*theta
+  call finalize_random_seed
 
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(zeta)
   zeta = 2.0_rp*C_PI*zeta
+  call finalize_random_seed
 
   ! Uniform distribution on a disk at a fixed azimuthal theta
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(r)
+  call finalize_random_seed
 
   r = SQRT((spp%r_outter**2 - spp%r_inner**2)*r + spp%r_inner**2)
 
@@ -426,14 +436,19 @@ subroutine exponential_torus(params,spp)
   call init_random_seed(params)
   call RANDOM_NUMBER(theta)
   theta = 2.0_rp*C_PI*theta
+  call finalize_random_seed
 
   call init_random_seed(params)
+!  FIXME: Is it really necessary to reset the seed here?
   call RANDOM_NUMBER(zeta)
   zeta = 2.0_rp*C_PI*zeta
+  call finalize_random_seed
 
   ! Uniform distribution on a disk at a fixed azimuthal theta
   call init_random_seed(params)
+!  FIXME: Is it really necessary to reset the seed here?
   call RANDOM_NUMBER(r)
+  call finalize_random_seed
 
   ! Newton-Raphson applied here for finding the radial distribution
   do pp=1_idef,spp%ppp
@@ -542,14 +557,19 @@ subroutine exponential_elliptic_torus(params,spp)
   call init_random_seed(params)
   call RANDOM_NUMBER(theta)
   theta = 2.0_rp*C_PI*theta
+  call finalize_random_seed
 
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(zeta)
   zeta = 2.0_rp*C_PI*zeta
+  call finalize_random_seed
 
   ! Uniform distribution on a disk at a fixed azimuthal theta
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(r)
+  call finalize_random_seed
 
   do pp=1_idef,spp%ppp
      rl = 0.0_rp
@@ -662,14 +682,19 @@ subroutine gaussian_elliptic_torus(params,spp)
   call init_random_seed(params)
   call RANDOM_NUMBER(theta)
   theta = 2.0_rp*C_PI*theta
+  call finalize_random_seed
 
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(zeta)
   zeta = 2.0_rp*C_PI*zeta
+  call finalize_random_seed
 
   ! Uniform distribution on a disk at a fixed azimuthal theta
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(r)
+  call finalize_random_seed
 
   sigma = 1.0_rp/SQRT(2.0_rp*(spp%falloff_rate/params%cpp%length))
   sigma = sigma/params%cpp%length
@@ -951,14 +976,19 @@ subroutine gaussian_torus(params,spp)
   call init_random_seed(params)
   call RANDOM_NUMBER(theta)
   theta = 2.0_rp*C_PI*theta
+  call finalize_random_seed
 
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(zeta)
   zeta = 2.0_rp*C_PI*zeta
+  call finalize_random_seed
 
   ! Uniform distribution on a disk at a fixed azimuthal theta
+!  FIXME: Is it really necessary to reset the seed here?
   call init_random_seed(params)
   call RANDOM_NUMBER(r)
+  call finalize_random_seed
 
   sigma = 1.0_rp/SQRT(2.0_rp*(spp%falloff_rate/params%cpp%length))
   sigma = sigma/params%cpp%length
@@ -1685,6 +1715,9 @@ subroutine MH_psi(params,spp,F)
 !     write(output_unit_write,*) 'G_samples',G_samples
 !     write(output_unit_write,*) 'eta_samples',eta_samples
 
+     if (.not.params%SameRandSeed) then
+        call init_random_seed(params)
+     end if
   end if
 
   params%GC_coords=.FALSE.
@@ -2153,6 +2186,9 @@ subroutine FIO_therm(params,spp,F,P)
      G_samples=1/sqrt(1-V_samples**2)
      ETA_samples=acos(XI_samples)*180/C_PI
 
+     if (.not.params%SameRandSeed) then
+        call init_random_seed(params)
+     end if
   end if
 
   params%GC_coords=.FALSE.
@@ -2633,6 +2669,9 @@ subroutine BMC_radial(params,spp,F,P)
 !     write(output_unit_write,*) 'G_samples',G_samples
 !     write(output_unit_write,*) 'eta_samples',eta_samples
 
+     if (.not.params%SameRandSeed) then
+        call init_random_seed(params)
+     end if
   end if
 
   params%GC_coords=.FALSE.

--- a/src/korc_velocity_distribution.f90
+++ b/src/korc_velocity_distribution.f90
@@ -476,6 +476,8 @@ CONTAINS
     DEALLOCATE(b2)
     DEALLOCATE(b3)
     DEALLOCATE(hint)
+
+    call finalize_random_seed
   end subroutine gyro_distribution
 
 

--- a/src/korc_velocity_distribution.f90
+++ b/src/korc_velocity_distribution.f90
@@ -415,6 +415,7 @@ CONTAINS
 
     call init_random_seed(params)
     call RANDOM_NUMBER(theta)
+    call finalize_random_seed
     theta = 2.0_rp*C_PI*theta
     
     if (spp%spatial_distribution.eq.'TRACER') theta=2.0*C_PI
@@ -476,8 +477,6 @@ CONTAINS
     DEALLOCATE(b2)
     DEALLOCATE(b3)
     DEALLOCATE(hint)
-
-    call finalize_random_seed
   end subroutine gyro_distribution
 
 

--- a/src/main.f90
+++ b/src/main.f90
@@ -727,6 +727,9 @@ end if
   call timing_KORC(params)
 
   ! * * * FINALIZING SIMULATION * * *
+
+  call take_down_particles_ic(params)
+
   call finalize_HDF5()
 
 #ifdef PSPLINE


### PR DESCRIPTION
This fixes memory leaks of random state objects by ensuring the destructors are called.