### PR TITLE
Early pspline check

### DIFF
--- a/src/korc_hpc.f90
+++ b/src/korc_hpc.f90
@@ -44,6 +44,7 @@ CONTAINS
     !! 24: korc_collisions:large_angle_source
     !! 25: korc_ppusher:adv_GCinterp_psiwE_top
     !! 26: korc_collisions:define_collisions_time_step
+    !! 27: main:initialize_fields_interpolant
 
     flush(output_unit_write)
     

--- a/src/main.f90
+++ b/src/main.f90
@@ -250,8 +250,6 @@ call initialize_profiles_interpolant(params,P)
   (params%field_eval.eq.'interp')).and. &
   (.not.TRIM(params%field_model).eq.'M3D_C1'.and. &
   .not.TRIM(params%field_model).eq.'NIMROD')) call KORC_ABORT(27)
-
-  endif
 #endif
   !! <h4>16\. Initialize Profiles Interpolant</h4>
   !!

--- a/src/main.f90
+++ b/src/main.f90
@@ -245,6 +245,13 @@ if (params%mpi_params%rank .EQ. 0) then
 end if
 
 call initialize_profiles_interpolant(params,P)
+#else
+  if (((params%field_model(1:8) .EQ. 'EXTERNAL').or. &
+  (params%field_eval.eq.'interp')).and. &
+  (.not.TRIM(params%field_model).eq.'M3D_C1'.and. &
+  .not.TRIM(params%field_model).eq.'NIMROD')) call KORC_ABORT(27)
+
+  endif
 #endif
   !! <h4>16\. Initialize Profiles Interpolant</h4>
   !!


### PR DESCRIPTION
Adds check during interpolant initialization to ensure interpolation library is included with build if asked for in input file.