### PR TITLE
Add CMake option HDF5_PRECISION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,18 @@ option (USE_ACC "Use OpenACC" OFF)
 option (USE_PSPLINE "Use PSPLINE interpolation" ON)
 option (USE_FIO "Use FIO interpolation support" OFF)
 
+set (VALID_PRECISIONS "FLOAT" "DOUBLE")
+set (HDF5_PRECISION "DOUBLE" CACHE STRING "FLOAT,DOUBLE")
+set_property (CACHE HDF5_PRECISION PROPERTY STRINGS ${VALID_PRECISIONS})
+
+if (HDF5_PRECISION STREQUAL "DOUBLE")
+  add_compile_options(-DHDF5_DOUBLE_PRESICION)
+elseif (HDF5_PRECISION STREQUAL "FLOAT")
+  add_compile_options(-DHDF5_FLOAT_PRESICION)
+else ()
+  message (FATAL_ERROR "HDF5_PRECISION value \"${HDF5_PRECISION}\" option set to something other than FLOAT or DOUBLE.")
+endif ()
+
 #-------------------------------------------------------------------------------
 #  Sanitizer options
 #-------------------------------------------------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ cmake -DCMAKE_BUILD_TYPE:String=$BUILD_TYPE \
       -DUSE_PSPLINE=ON \
       -DUSE_FIO=OFF \
       -DKORC_TEST=OFF \
-      -DCMAKE_Fortran_FLAGS="-DHDF5_DOUBLE_PRESICION -malign-double -fconvert='big-endian'" \
+      -DCMAKE_Fortran_FLAGS="-malign-double -fconvert='big-endian'" \
       -DCMAKE_C_FLAGS="-malign-double"  \
       -DCMAKE_CXX_FLAGS="-malign-double" \
       -DCMAKE_Fortran_FLAGS_DEBUG="-g3 -ffpe-trap=zero,overflow -fbacktrace" \


### PR DESCRIPTION
This adds a CMake option `HDF5_PRECISION` to set either the `DOUBLE_PRESICION` or `FLOAT_PRESICION` macro and print an error if neither are set. The default value is `DOUBLE`.

![image](https://github.com/ORNL-Fusion/KORC/assets/5920552/18bba0fe-22ec-43ce-a892-94060bd68efe)