### PR TITLE
specify runner milan0

### DIFF
--- a/.github/workflows/onyx.yml
+++ b/.github/workflows/onyx.yml
@@ -31,7 +31,7 @@ jobs:
 
 
   job_setup_workdir:
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, milan0 ]
     needs: [ job_verify_actor ]
     steps:
       - name: GitHub API Request
@@ -53,7 +53,7 @@ jobs:
 
   job_build_cpu:
     if: true
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, milan0 ]
     needs: [ job_verify_actor, job_setup_workdir ]
     defaults:
       run:
@@ -71,7 +71,7 @@ jobs:
 
   job_setup_spack:
     if: true
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, milan0 ]
     needs: [ job_verify_actor, job_setup_workdir ]
     defaults:
       run:
@@ -118,7 +118,7 @@ jobs:
 
   job_build_gpu:
     if: true
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, milan0 ]
     needs: [ job_verify_actor, job_setup_spack, job_setup_workdir ]
     defaults:
       run:
@@ -139,7 +139,7 @@ jobs:
 
   job_test_cpu:
     if: true
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, milan0 ]
     needs: [ job_verify_actor, job_build_cpu, job_setup_workdir ]
     defaults:
       run:
@@ -163,7 +163,7 @@ jobs:
 
   job_test_gpu:
     if: true
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, milan0 ]
     needs: [ job_verify_actor, job_setup_spack, job_build_gpu, job_setup_workdir ]
     defaults:
       run:


### PR DESCRIPTION
CI workflow was hopping between milan0 and milan2.  This change stipulates that onyx workflow only runs on milan0